### PR TITLE
added verbose option to ganache-cli

### DIFF
--- a/scripts/launch
+++ b/scripts/launch
@@ -20,6 +20,7 @@ while [[ "$#" > 0 ]]; do case $1 in
   -p|--port) PORT="$2"; shift;;
   -s|--snapshot) snapshot="$2"; shift;;
   --template) TEMPLATE="$2"; shift;;
+  --verbose) verbose=1;;
   *) otherargs+=($1);;
 esac; shift; done
 
@@ -63,11 +64,19 @@ if ! nc -z 127.0.0.1 $PORT; then
     yarn install
     cd -
   fi
+  
   echo "Starting Ganache..."
-  $GANACHE_CLI --noVMErrorsOnRPCResponse -i 999 -p $PORT -a 1000 \
-    -m "hill law jazz limb penalty escape public dish stand bracket blue jar" \
-    --db $VAR/chaindata \
-    > $VAR/ganache.out 2>&1 & netpid=$!
+  if [ $verbose ]; then
+    $GANACHE_CLI --noVMErrorsOnRPCResponse -i 999 -p $PORT -a 1000 \
+      -m "hill law jazz limb penalty escape public dish stand bracket blue jar" \
+      --db $VAR/chaindata \
+      2>&1 & netpid=$!
+  else
+    $GANACHE_CLI --noVMErrorsOnRPCResponse -i 999 -p $PORT -a 1000 \
+      -m "hill law jazz limb penalty escape public dish stand bracket blue jar" \
+      --db $VAR/chaindata \
+      > $VAR/ganache.out 2>&1 & netpid=$!
+  fi
 
   # Wait for the testnet to become responsive
   until curl -s -o/dev/null "$ETH_RPC_URL"; do


### PR DESCRIPTION
In playing with the testchain, I have noticed there's no --verbose option to see state changes. 
This pull request added the verbsoe option. I simply copied it from mcd branch. 